### PR TITLE
Invalidated Optional Warning with Exceptions

### DIFF
--- a/src/main/java/net/robinfriedli/aiode/audio/spotify/SpotifyTrackResultHandler.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/spotify/SpotifyTrackResultHandler.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.text.similarity.LevenshteinDistance;
 

--- a/src/main/java/net/robinfriedli/aiode/audio/spotify/SpotifyTrackResultHandler.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/spotify/SpotifyTrackResultHandler.java
@@ -69,19 +69,19 @@ public class SpotifyTrackResultHandler {
         }
 
         int bestScore = tracksByScore.keySet().stream().mapToInt(k -> k).max().getAsInt();
-        Track bestScoringTrack = null;
+        final AtomicReference<Track> bestScoringTrackRef = new AtomicReference<Track>();
 
         tracksByScore
             .get(bestScore)
             .stream()
             .max(Comparator.comparing(Track::getPopularity))
-            .ifPresent(bestTrack -> { bestScoringTrack = bestTrack; });
+            .ifPresent(bestScoringTrack -> { bestScoringTrackRef.set(bestScoringTrack); });
 
-        if (bestScoringTrack == null) {
+        if (bestScoringTrackRef.get() == null) {
             throw new NoSpotifyResultsFoundException(String.format("No Spotify track found when looking for best scoring track with score '%d'", bestScore));
         }
 
-        return bestScoringTrack;
+        return bestScoringTrackRef.get();
     }
 
     /**


### PR DESCRIPTION
## SonarQube Report
Fixed the following bug found by SonarQube:
![optionalBug_where](https://user-images.githubusercontent.com/29316659/192916525-517ff88a-2fe6-49ea-b1a8-7b2846388ae9.png)

![optionalBug_why](https://user-images.githubusercontent.com/29316659/192916411-b9188a78-18f5-414c-ba8b-6cf0843e65b5.png)

## Description
According to SonarQube, an unguarded optional is returned by either of:
- `HashMultimap.get(<int>)`                   -> This is impossible as the key is generated from the map's keys themselves
- `Collection.stream()`                               -> Which returns a stream (of optional values, but the stream isn't optional itself)
- `Stream.max(<Comparing_Function>) `   -> [Documentation Link](https://www.geeksforgeeks.org/stream-max-method-java-examples/)

As described by SonarQube, there are usually a few ways around this type of problem. A few points about the chosen approach:

- In this case, the direct return structure of the method can't really be maintained as optional guards such as `ifPresent(<lambda_function>)` have `void` return types.  
- `getBestResult()`  now throws a `NoSpotifyResultsFoundException`. This is backward compatible with the rest of the codebase as the only place  `getBestResult()`  is called is [here](https://github.com/McGill-ECSE429-Fall2022/assignment-1-team-24/blob/master/src/main/java/net/robinfriedli/aiode/command/commands/AbstractPlayableLoadingCommand.java#L260), and that method throws the more general `Exception` itself.
- Given the explicit `SurpressWarning()` that was present beforehand, it is likely that the author intended that an exception such as the one added by this commit shall never need to be triggered. The new code is definitely less readable than the old one, so whether this change is actually worth it or now is up for debate.
