### PR TITLE
Re-interrupt threads after catching InterruptedException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 /logs/
 /src/main/resources/settings-private.properties
 /derby.log
+# Eclipse files
+/bin/
+.classpath
+.project
+.settings/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id "eclipse"
     id "java"
     id "org.springframework.boot" version "2.7.4"
     id "org.jetbrains.kotlin.jvm" version "1.6.20"

--- a/src/main/java/net/robinfriedli/aiode/Aiode.java
+++ b/src/main/java/net/robinfriedli/aiode/Aiode.java
@@ -209,6 +209,7 @@ public class Aiode {
                 Thread.sleep(millisToWait);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                return;
             }
             System.exit(0);
         });

--- a/src/main/java/net/robinfriedli/aiode/Aiode.java
+++ b/src/main/java/net/robinfriedli/aiode/Aiode.java
@@ -208,7 +208,7 @@ public class Aiode {
             try {
                 Thread.sleep(millisToWait);
             } catch (InterruptedException e) {
-                return;
+                Thread.currentThread().interrupt();
             }
             System.exit(0);
         });
@@ -227,6 +227,7 @@ public class Aiode {
                     try {
                         futureMessage.get();
                     } catch (InterruptedException e) {
+                    	Thread.currentThread().interrupt();
                         break;
                     } catch (ExecutionException e) {
                         continue;

--- a/src/main/java/net/robinfriedli/aiode/audio/youtube/HollowYouTubeVideo.java
+++ b/src/main/java/net/robinfriedli/aiode/audio/youtube/HollowYouTubeVideo.java
@@ -164,6 +164,7 @@ public class HollowYouTubeVideo extends AbstractSoftCachedPlayable implements Yo
                 return future.get(3, TimeUnit.MINUTES);
             }
         } catch (InterruptedException | ExecutionException e) {
+        	Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (TimeoutException e) {
             throw new RuntimeException("Video loading timed out", e);
@@ -176,6 +177,7 @@ public class HollowYouTubeVideo extends AbstractSoftCachedPlayable implements Yo
         try {
             return future.get(time, unit);
         } catch (InterruptedException | ExecutionException e) {
+        	Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (CancellationException e) {
             throw new UnavailableResourceException();

--- a/src/main/java/net/robinfriedli/aiode/command/commands/admin/AudioTrafficSimulationCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/admin/AudioTrafficSimulationCommand.java
@@ -208,6 +208,7 @@ public class AudioTrafficSimulationCommand extends AbstractAdminCommand {
 
                 Thread.sleep(durationSecs * 1000L);
             } catch (InterruptedException e) {
+            	Thread.currentThread().interrupt();
                 // continue to interrupt threads
             } catch (Exception e) {
                 logger.error("Unexpected exception while managing fake players", e);
@@ -266,6 +267,7 @@ public class AudioTrafficSimulationCommand extends AbstractAdminCommand {
                     Thread.sleep(20);
                 } catch (InterruptedException e) {
                     player.stopTrack();
+                    Thread.currentThread().interrupt();
                     return;
                 }
             }

--- a/src/main/java/net/robinfriedli/aiode/command/commands/admin/CleanDbCommand.java
+++ b/src/main/java/net/robinfriedli/aiode/command/commands/admin/CleanDbCommand.java
@@ -58,6 +58,7 @@ public class CleanDbCommand extends AbstractAdminCommand {
                     try {
                         executionQueueManager.joinAll(60000);
                     } catch (InterruptedException e) {
+                    	Thread.currentThread().interrupt();
                         return;
                     }
 

--- a/src/main/java/net/robinfriedli/aiode/command/interceptor/interceptors/CommandMonitoringInterceptor.java
+++ b/src/main/java/net/robinfriedli/aiode/command/interceptor/interceptors/CommandMonitoringInterceptor.java
@@ -89,6 +89,7 @@ public class CommandMonitoringInterceptor extends AbstractChainableCommandInterc
             } catch (InterruptedException e) {
                 // CommandExecutionInterceptor interrupts monitoring in post command
                 deleteMessages(stillLoadingMessage, warningMessage);
+                Thread.currentThread().interrupt();
             } finally {
                 thread.setName(oldName);
             }

--- a/src/main/java/net/robinfriedli/aiode/concurrent/EagerlyScalingThreadPoolExecutor.java
+++ b/src/main/java/net/robinfriedli/aiode/concurrent/EagerlyScalingThreadPoolExecutor.java
@@ -109,6 +109,7 @@ public class EagerlyScalingThreadPoolExecutor extends ThreadPoolExecutor {
                             this.currentWorker.compareAndSet(Thread.currentThread(), null);
                         } catch (InterruptedException e) {
                             this.currentWorker.compareAndSet(Thread.currentThread(), null);
+                            Thread.currentThread().interrupt();
                         }
                     });
 

--- a/src/main/java/net/robinfriedli/aiode/concurrent/QueuedTask.java
+++ b/src/main/java/net/robinfriedli/aiode/concurrent/QueuedTask.java
@@ -141,6 +141,7 @@ public class QueuedTask implements Runnable {
         try {
             slot = queue.takeSlot();
         } catch (InterruptedException e) {
+        	Thread.currentThread().interrupt();
             return;
         }
 

--- a/src/main/java/net/robinfriedli/aiode/scripting/SafeGroovyScriptRunner.java
+++ b/src/main/java/net/robinfriedli/aiode/scripting/SafeGroovyScriptRunner.java
@@ -215,6 +215,7 @@ public class SafeGroovyScriptRunner {
             return null;
         } catch (InterruptedException e) {
             result.cancel(true);
+            Thread.currentThread().interrupt();
             return null;
         } catch (TimeoutException e) {
             result.cancel(true);


### PR DESCRIPTION
I tried not catching the exception at all, but it turns out `InterruptedException` is a checked exception. In most cases I just added `Thread.currentThread().interrupt()` as SonarQube suggested. In some cases the developer named the exception `ignored`, so I assumed that was intentional and left it as-is.